### PR TITLE
Fix link that choosenim uses to find latest version

### DIFF
--- a/src/choosenim.nim
+++ b/src/choosenim.nim
@@ -1,6 +1,6 @@
 # Copyright (C) Dominik Picheta. All rights reserved.
 # BSD-3-Clause License. Look at license.txt for more info.
-import os, strutils, algorithm
+import os, strutils, algorithm, sugar
 
 import nimblepkg/[cli, version]
 import nimblepkg/common as nimbleCommon
@@ -136,8 +136,10 @@ proc choose(params: CliParams) =
 
 proc updateSelf(params: CliParams) =
   display("Updating", "choosenim", priority = HighPriority)
-
-  let version = getChannelVersion("self", params, live=true).newVersion
+  # So I did a lil oopsie and added a `v` because it was easier
+  # turns out there is a reason it doesn't have a v
+  # TODO: Remove this v stripping prefix nonsense in a later version
+  let version = getChannelVersion("self", params, live=true).dup(removePrefix("v")).newVersion
   if not params.force and version <= chooseNimVersion.newVersion:
     display("Info:", "Already up to date at version " & chooseNimVersion,
             Success, HighPriority)

--- a/src/choosenim.nim
+++ b/src/choosenim.nim
@@ -148,7 +148,7 @@ proc updateSelf(params: CliParams) =
   # https://stackoverflow.com/a/9163044/492186
   let tag = "v" & $version
   let filename = "choosenim-" & $version & "_" & hostOS & "_" & hostCPU.addFileExt(ExeExt)
-  let url = "https://github.com/dom96/choosenim/releases/download/$1/$2" % [
+  let url = "https://github.com/ire4ever1190/choosenim/releases/download/$1/$2" % [
     tag, filename
   ]
   let newFilename = getAppDir() / "choosenim_new".addFileExt(ExeExt)

--- a/src/choosenim.nim
+++ b/src/choosenim.nim
@@ -147,7 +147,7 @@ proc updateSelf(params: CliParams) =
 
   # https://stackoverflow.com/a/9163044/492186
   let tag = "v" & $version
-  let filename = "choosenim-" & $version & "_" & hostOS & "_" & hostCPU.addFileExt(ExeExt)
+  let filename = "choosenim-" & tag & "_" & hostOS & "_" & hostCPU.addFileExt(ExeExt)
   let url = "https://github.com/ire4ever1190/choosenim/releases/download/$1/$2" % [
     tag, filename
   ]

--- a/src/choosenimpkg/channel.nim
+++ b/src/choosenimpkg/channel.nim
@@ -10,9 +10,9 @@ import download, cliparams, switcher
 
 let
   channels = {
-    "stable": "http://nim-lang.org/channels/stable",
+    "stable": "https://nim-lang.org/channels/stable",
     "devel": "#devel",
-    "self": "https://nim-lang.org/choosenim/stable"
+    "self": "https://choosenim.leahy.dev/stable"
   }.toTable()
 
 proc isReleaseChannel*(command: string): bool =

--- a/src/choosenimpkg/proxyexe.nim
+++ b/src/choosenimpkg/proxyexe.nim
@@ -70,5 +70,5 @@ when isMainModule:
       display("Hint:", hint, Warning, HighPriority)
 
     display("Info:", "If unexpected, please report this error to " &
-            "https://github.com/dom96/choosenim", Warning, HighPriority)
+            "https://github.com/ire4ever1190/choosenim", Warning, HighPriority)
     quit(1)


### PR DESCRIPTION
Install wasn't able to auto update since it was checking the official choosenim version to see if it was up-to-date